### PR TITLE
feat: Add multi-provider LLM settings with persistent storage

### DIFF
--- a/backend/database/models.py
+++ b/backend/database/models.py
@@ -96,3 +96,16 @@ class MCPServer(BaseModel):
     enabled: bool = True
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class LLMProvider(BaseModel):
+    """LLM provider configuration."""
+
+    id: str = Field(default_factory=generate_uuid)
+    name: str  # Provider key: ollama, openai, cerebras, etc.
+    base_url: str
+    api_key: Optional[str] = None
+    model: Optional[str] = None
+    is_default: bool = False
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)


### PR DESCRIPTION
- Add llm_providers database table to store provider configurations
- Add LLMProvider Pydantic model
- Add repository CRUD methods for LLM providers
- Add API endpoints for provider management:
  - GET/PUT/DELETE /settings/llm/providers/{name}
  - POST /settings/llm/providers/{name}/default
  - GET /settings/llm/providers (list all)
- Update Settings.tsx to show saved/default provider indicators
- Auto-load saved settings when switching providers
- Migrate existing LLM config to new providers table
- Maintain backward compatibility with existing endpoints