### PR TITLE
fix: Consolidate LLM provider storage and fix database initialization

### DIFF
--- a/backend/api/settings.py
+++ b/backend/api/settings.py
@@ -29,7 +29,7 @@ class LLMSettingsResponse(BaseModel):
 
     provider: str
     base_url: str
-    api_key: str  # Masked
+    api_key: str
     model: str
     available: bool
     is_default: bool = False
@@ -40,7 +40,7 @@ class LLMProviderResponse(BaseModel):
 
     name: str
     base_url: str
-    api_key: str  # Masked
+    api_key: str
     model: str
     is_default: bool
 
@@ -59,17 +59,8 @@ class SettingsResponse(BaseModel):
     app: dict
 
 
-def _mask_api_key(api_key: str) -> str:
-    """Mask API key for display."""
-    if not api_key or api_key == "not-required":
-        return api_key
-    if len(api_key) <= 8:
-        return "*" * len(api_key)
-    return api_key[:4] + "*" * (len(api_key) - 8) + api_key[-4:]
-
-
 def _get_default_provider_settings() -> dict:
-    """Get the default provider settings or fall back to config."""
+    """Get the default provider settings from llm_providers table."""
     default_provider = config_repo.get_default_llm_provider()
     if default_provider:
         return {
@@ -79,14 +70,13 @@ def _get_default_provider_settings() -> dict:
             "model": default_provider.model or "",
             "is_default": True,
         }
-    # Fall back to old config system for backward compatibility
-    llm_config = config_repo.get_config_value("llm", {})
+    # Return defaults from settings if no provider configured
     return {
-        "provider": llm_config.get("provider", settings.llm_provider),
-        "base_url": llm_config.get("base_url", settings.llm_base_url),
-        "api_key": llm_config.get("api_key", settings.llm_api_key),
-        "model": llm_config.get("model", settings.llm_model),
-        "is_default": True,
+        "provider": settings.llm_provider,
+        "base_url": settings.llm_base_url,
+        "api_key": settings.llm_api_key,
+        "model": settings.llm_model,
+        "is_default": False,
     }
 
 
@@ -99,7 +89,7 @@ async def get_settings() -> SettingsResponse:
         llm=LLMSettingsResponse(
             provider=provider_settings["provider"],
             base_url=provider_settings["base_url"],
-            api_key=_mask_api_key(provider_settings["api_key"]),
+            api_key=provider_settings["api_key"],
             model=provider_settings["model"],
             available=llm_service.is_available(),
             is_default=provider_settings["is_default"],
@@ -120,7 +110,7 @@ async def get_llm_settings() -> LLMSettingsResponse:
     return LLMSettingsResponse(
         provider=provider_settings["provider"],
         base_url=provider_settings["base_url"],
-        api_key=_mask_api_key(provider_settings["api_key"]),
+        api_key=provider_settings["api_key"],
         model=provider_settings["model"],
         available=llm_service.is_available(),
         is_default=provider_settings["is_default"],
@@ -135,16 +125,18 @@ async def update_llm_settings(request: LLMSettingsRequest) -> LLMSettingsRespons
     # Get existing provider or create new
     existing = config_repo.get_llm_provider(provider_name)
 
+    # Determine if we have a new API key to set
+    new_api_key = request.api_key if request.api_key else None
+
     if existing:
         # Update existing provider
         if request.base_url is not None:
             existing.base_url = request.base_url
-        if request.api_key is not None:
-            existing.api_key = request.api_key
         if request.model is not None:
             existing.model = request.model
         existing.is_default = True
-        provider = config_repo.update_llm_provider(existing)
+        # Pass new_api_key separately - if None, existing encrypted key is preserved
+        provider = config_repo.update_llm_provider(existing, new_api_key=new_api_key)
     else:
         # Create new provider
         provider = LLMProvider(
@@ -159,25 +151,20 @@ async def update_llm_settings(request: LLMSettingsRequest) -> LLMSettingsRespons
     # Set as default (unsets others)
     config_repo.set_default_llm_provider(provider_name)
 
-    # Also update old config for backward compatibility
-    config_repo.set_config("llm", {
-        "provider": provider.name,
-        "base_url": provider.base_url,
-        "api_key": provider.api_key or "",
-        "model": provider.model or "",
-    }, category="llm")
+    # Get the provider with decrypted API key for the LLM service
+    provider_for_use = config_repo.get_llm_provider_for_use(provider_name)
 
-    # Update the global LLM service
+    # Update the global LLM service with decrypted API key
     llm_service.update_config(
-        base_url=provider.base_url,
-        api_key=provider.api_key,
-        model=provider.model,
+        base_url=provider_for_use.base_url,
+        api_key=provider_for_use.api_key,
+        model=provider_for_use.model,
     )
 
     return LLMSettingsResponse(
         provider=provider.name,
         base_url=provider.base_url,
-        api_key=_mask_api_key(provider.api_key or ""),
+        api_key=provider_for_use.api_key or "",
         model=provider.model or "",
         available=llm_service.is_available(),
         is_default=True,
@@ -197,7 +184,7 @@ async def get_llm_providers() -> LLMProvidersListResponse:
             LLMProviderResponse(
                 name=p.name,
                 base_url=p.base_url,
-                api_key=_mask_api_key(p.api_key or ""),
+                api_key=p.api_key or "",
                 model=p.model or "",
                 is_default=p.is_default,
             )
@@ -218,7 +205,7 @@ async def get_llm_provider(name: str) -> LLMProviderResponse:
     return LLMProviderResponse(
         name=provider.name,
         base_url=provider.base_url,
-        api_key=_mask_api_key(provider.api_key or ""),
+        api_key=provider.api_key or "",
         model=provider.model or "",
         is_default=provider.is_default,
     )
@@ -229,15 +216,17 @@ async def update_llm_provider(name: str, request: LLMSettingsRequest) -> LLMProv
     """Create or update a specific LLM provider."""
     existing = config_repo.get_llm_provider(name)
 
+    # Determine if we have a new API key to set
+    new_api_key = request.api_key if request.api_key else None
+
     if existing:
         # Update existing
         if request.base_url is not None:
             existing.base_url = request.base_url
-        if request.api_key is not None:
-            existing.api_key = request.api_key
         if request.model is not None:
             existing.model = request.model
-        provider = config_repo.update_llm_provider(existing)
+        # Pass new_api_key separately - if None, existing key is preserved
+        provider = config_repo.update_llm_provider(existing, new_api_key=new_api_key)
     else:
         # Create new
         provider = LLMProvider(
@@ -252,7 +241,7 @@ async def update_llm_provider(name: str, request: LLMSettingsRequest) -> LLMProv
     return LLMProviderResponse(
         name=provider.name,
         base_url=provider.base_url,
-        api_key=_mask_api_key(provider.api_key or ""),
+        api_key=provider.api_key or "",
         model=provider.model or "",
         is_default=provider.is_default,
     )
@@ -277,19 +266,14 @@ async def set_default_llm_provider(name: str) -> LLMProviderResponse:
 
     config_repo.set_default_llm_provider(name)
 
-    # Also update old config for backward compatibility
-    config_repo.set_config("llm", {
-        "provider": provider.name,
-        "base_url": provider.base_url,
-        "api_key": provider.api_key or "",
-        "model": provider.model or "",
-    }, category="llm")
+    # Get provider with decrypted API key for the LLM service
+    provider_for_use = config_repo.get_llm_provider_for_use(name)
 
-    # Update the global LLM service
+    # Update the global LLM service with decrypted API key
     llm_service.update_config(
-        base_url=provider.base_url,
-        api_key=provider.api_key,
-        model=provider.model,
+        base_url=provider_for_use.base_url,
+        api_key=provider_for_use.api_key,
+        model=provider_for_use.model,
     )
 
     # Refresh provider to get updated is_default
@@ -298,7 +282,7 @@ async def set_default_llm_provider(name: str) -> LLMProviderResponse:
     return LLMProviderResponse(
         name=provider.name,
         base_url=provider.base_url,
-        api_key=_mask_api_key(provider.api_key or ""),
+        api_key=provider_for_use.api_key or "",
         model=provider.model or "",
         is_default=provider.is_default,
     )
@@ -334,13 +318,14 @@ async def test_llm_connection(request: LLMSettingsRequest) -> dict:
     """Test LLM connection with provided settings."""
     from services.llm_service import LLMService, ChatMessage
 
-    # Use provided settings or current ones
-    llm_config = config_repo.get_config_value("llm", {})
+    # Get current default provider settings (with decrypted API key)
+    default_provider = config_repo.get_default_llm_provider_for_use()
 
+    # Use provided settings or current ones from llm_providers table
     test_service = LLMService(
-        base_url=request.base_url or llm_config.get("base_url", settings.llm_base_url),
-        api_key=request.api_key or llm_config.get("api_key", settings.llm_api_key),
-        model=request.model or llm_config.get("model", settings.llm_model),
+        base_url=request.base_url or (default_provider.base_url if default_provider else settings.llm_base_url),
+        api_key=request.api_key or (default_provider.api_key if default_provider else settings.llm_api_key),
+        model=request.model or (default_provider.model if default_provider else settings.llm_model),
     )
 
     try:
@@ -414,13 +399,14 @@ async def fetch_available_models(request: LLMSettingsRequest) -> dict:
     """Fetch available models based on provided settings."""
     from services.llm_service import LLMService
 
-    # Use provided settings or current ones
-    llm_config = config_repo.get_config_value("llm", {})
+    # Get current default provider settings (with decrypted API key)
+    default_provider = config_repo.get_default_llm_provider_for_use()
 
+    # Use provided settings or current ones from llm_providers table
     service = LLMService(
-        base_url=request.base_url or llm_config.get("base_url", settings.llm_base_url),
-        api_key=request.api_key or llm_config.get("api_key", settings.llm_api_key),
-        model=request.model or llm_config.get("model", settings.llm_model),
+        base_url=request.base_url or (default_provider.base_url if default_provider else settings.llm_base_url),
+        api_key=request.api_key or (default_provider.api_key if default_provider else settings.llm_api_key),
+        model=request.model or (default_provider.model if default_provider else settings.llm_model),
     )
 
     try:

--- a/backend/database/connection.py
+++ b/backend/database/connection.py
@@ -157,6 +157,9 @@ def _migrate_db(conn: sqlite3.Connection) -> None:
                     """,
                     (str(uuid.uuid4()), provider_name, base_url, api_key, model),
                 )
+
+                # Delete the legacy configuration entry
+                conn.execute("DELETE FROM configurations WHERE key = 'llm'")
             except (json.JSONDecodeError, KeyError):
                 pass
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -10,6 +10,10 @@ from fastapi.middleware.cors import CORSMiddleware
 from config import settings
 from database.connection import init_db
 
+# Initialize database early - before routers are imported
+# This ensures tables exist even in reload mode
+init_db()
+
 # Configure logging
 logging.basicConfig(
     level=logging.INFO,

--- a/backend/services/llm_service.py
+++ b/backend/services/llm_service.py
@@ -32,11 +32,22 @@ def clean_llm_output(text: str) -> str:
 
 
 def _get_llm_config_from_db() -> dict:
-    """Get LLM configuration from the database."""
+    """Get LLM configuration from the database (llm_providers table)."""
     try:
         from database.repositories.config_repository import ConfigRepository
         config_repo = ConfigRepository()
-        return config_repo.get_config_value("llm", {})
+
+        # Get default provider with decrypted API key
+        default_provider = config_repo.get_default_llm_provider_for_use()
+        if default_provider:
+            return {
+                "provider": default_provider.name,
+                "base_url": default_provider.base_url,
+                "api_key": default_provider.api_key or "",
+                "model": default_provider.model or "",
+            }
+
+        return {}
     except Exception:
         # Database might not be initialized yet
         return {}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -52,7 +52,7 @@ interface LLMSettings {
 interface SavedProvider {
   name: string
   base_url: string
-  api_key: string  // Masked from API
+  api_key: string
   model: string
   is_default: boolean
 }
@@ -62,7 +62,7 @@ const PROVIDER_CONFIGS: Record<string, { url: string; requiresApiKey: boolean; p
   ollama: {
     url: "http://localhost:11434/v1",
     requiresApiKey: false,
-    placeholder: "llama3:instruct",
+    placeholder: "ministral-3",
   },
   openai: {
     url: "https://api.openai.com/v1",
@@ -77,12 +77,12 @@ const PROVIDER_CONFIGS: Record<string, { url: string; requiresApiKey: boolean; p
   gemini: {
     url: "https://generativelanguage.googleapis.com/v1beta/openai",
     requiresApiKey: true,
-    placeholder: "gemini-2.0-flash",
+    placeholder: "gemini-2.5-flash",
   },
   cerebras: {
     url: "https://api.cerebras.ai/v1",
     requiresApiKey: true,
-    placeholder: "llama-4-scout-17b-16e-instruct",
+    placeholder: "zai-glm-4.6",
   },
   claude: {
     url: "https://api.anthropic.com/v1",
@@ -170,7 +170,7 @@ export default function Settings() {
         setEditedLlm({
           provider: data.provider,
           base_url: data.base_url,
-          api_key: "",  // Don't show masked key
+          api_key: data.api_key || "",  // Use masked API key from backend
           model: data.model,
         })
       }
@@ -199,7 +199,6 @@ export default function Settings() {
   const loadAvailableModels = async () => {
     try {
       setModelsLoading(true)
-      // Use the new POST endpoint that accepts current settings
       const response = await fetch(`${API_BASE_URL}/api/v1/settings/llm/models`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -553,11 +552,11 @@ export default function Settings() {
                               const config = PROVIDER_CONFIGS[value]
 
                               if (savedProvider) {
-                                // Use saved settings (but clear api_key since it's masked)
+                                // Use saved settings with masked API key from backend
                                 setEditedLlm({
                                   provider: value,
                                   base_url: savedProvider.base_url,
-                                  api_key: "",  // Clear - user can re-enter if needed
+                                  api_key: savedProvider.api_key || "",
                                   model: savedProvider.model,
                                 })
                               } else {


### PR DESCRIPTION
- Remove dual-write to configurations table, use only llm_providers
- Call init_db() early in main.py to ensure tables exist before use
- Add new_api_key parameter to update_llm_provider to preserve existing keys
- Simplify API key handling: return actual values with password input on frontend
- Remove legacy configurations['llm'] fallbacks throughout codebase
- Update Settings.tsx to use password type input with show/hide toggle