### PR TITLE
feat: Add Rails-style database migration system

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,51 @@
+# LocalMind Project Rules
+
+## Database Changes - CRITICAL
+
+**NEVER modify the database schema directly in `connection.py` or any other file.**
+
+All database schema changes MUST be done through migrations:
+
+1. Create a new migration file in `backend/database/migrations/`
+2. Name format: `YYYYMMDDHHMMSS_description.py`
+3. Include VERSION, DESCRIPTION, and up() function
+4. Use `CREATE TABLE IF NOT EXISTS` for new tables
+5. Check column existence before `ALTER TABLE ADD COLUMN`
+
+Example migration:
+```python
+"""Add new feature table."""
+import sqlite3
+
+VERSION = "20241220150000"
+DESCRIPTION = "Add new feature table"
+
+def up(conn: sqlite3.Connection) -> None:
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS new_table (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL
+        )
+    """)
+```
+
+## Configuration
+
+- All config in `app.config.json` (single source of truth)
+- Backend imports: `from config.settings import settings`
+- Frontend imports: `import { API_BASE_URL } from "@/config/app-config"`
+- Never hardcode URLs, ports, or model names
+
+## Tech Stack
+
+- Frontend: React + TypeScript + Shadcn UI + Zustand
+- Backend: Python FastAPI
+- Database: SQLite with migration system
+- Desktop: Tauri
+
+## Code Style
+
+- Use TypeScript strict mode
+- Prefer functional components with hooks
+- Use Zustand for state management
+- Follow existing code patterns in the codebase

--- a/backend/database/connection.py
+++ b/backend/database/connection.py
@@ -7,95 +7,6 @@ from typing import Generator
 
 from config import settings
 
-# SQL schema for all tables
-SCHEMA = """
--- Chats table
-CREATE TABLE IF NOT EXISTS chats (
-    id TEXT PRIMARY KEY,
-    title TEXT NOT NULL DEFAULT 'New Chat',
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    is_archived INTEGER DEFAULT 0,
-    is_pinned INTEGER DEFAULT 0
-);
-
--- Chat tags
-CREATE TABLE IF NOT EXISTS chat_tags (
-    id TEXT PRIMARY KEY,
-    name TEXT UNIQUE NOT NULL,
-    color TEXT DEFAULT '#6B7280'
-);
-
--- Chat tag assignments (many-to-many)
-CREATE TABLE IF NOT EXISTS chat_tag_assignments (
-    chat_id TEXT NOT NULL,
-    tag_id TEXT NOT NULL,
-    PRIMARY KEY (chat_id, tag_id),
-    FOREIGN KEY (chat_id) REFERENCES chats(id) ON DELETE CASCADE,
-    FOREIGN KEY (tag_id) REFERENCES chat_tags(id) ON DELETE CASCADE
-);
-
--- Messages table
-CREATE TABLE IF NOT EXISTS messages (
-    id TEXT PRIMARY KEY,
-    chat_id TEXT NOT NULL,
-    role TEXT NOT NULL CHECK(role IN ('user', 'assistant', 'system')),
-    content TEXT NOT NULL,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    artifact_type TEXT,
-    artifact_data JSON,
-    FOREIGN KEY (chat_id) REFERENCES chats(id) ON DELETE CASCADE
-);
-CREATE INDEX IF NOT EXISTS idx_messages_chat_id ON messages(chat_id);
-CREATE INDEX IF NOT EXISTS idx_messages_created_at ON messages(created_at);
-
--- Transcripts table (YouTube video transcripts)
-CREATE TABLE IF NOT EXISTS transcripts (
-    id TEXT PRIMARY KEY,
-    video_id TEXT UNIQUE NOT NULL,
-    video_url TEXT NOT NULL,
-    video_title TEXT,
-    language_code TEXT DEFAULT 'en',
-    is_generated INTEGER DEFAULT 0,
-    raw_transcript JSON,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
-CREATE INDEX IF NOT EXISTS idx_transcripts_video_id ON transcripts(video_id);
-
--- Configurations table
-CREATE TABLE IF NOT EXISTS configurations (
-    key TEXT PRIMARY KEY,
-    value JSON NOT NULL,
-    category TEXT DEFAULT 'general'
-);
-
--- MCP Servers table
-CREATE TABLE IF NOT EXISTS mcp_servers (
-    id TEXT PRIMARY KEY,
-    name TEXT UNIQUE NOT NULL,
-    transport_type TEXT NOT NULL CHECK(transport_type IN ('stdio', 'sse')),
-    command TEXT,
-    args JSON,
-    url TEXT,
-    env JSON,
-    enabled INTEGER DEFAULT 1,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
-
--- LLM Providers table
-CREATE TABLE IF NOT EXISTS llm_providers (
-    id TEXT PRIMARY KEY,
-    name TEXT UNIQUE NOT NULL,
-    base_url TEXT NOT NULL,
-    api_key TEXT,
-    model TEXT,
-    is_default INTEGER DEFAULT 0,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
-"""
-
 
 def get_db_path() -> Path:
     """Get the database file path, creating parent directories if needed."""
@@ -105,69 +16,19 @@ def get_db_path() -> Path:
 
 
 def init_db() -> None:
-    """Initialize the database with schema."""
+    """Initialize the database and run pending migrations."""
+    from database.migrator import run_migrations
+
     db_path = get_db_path()
     conn = sqlite3.connect(str(db_path))
-    conn.executescript(SCHEMA)
-    
-    # Run migrations
-    _migrate_db(conn)
-    
-    conn.commit()
-    conn.close()
 
-
-def _migrate_db(conn: sqlite3.Connection) -> None:
-    """Run database migrations."""
-    import json
-    import uuid
-
-    # Check if is_pinned column exists in chats table
-    cursor = conn.execute("PRAGMA table_info(chats)")
-    columns = [row[1] for row in cursor.fetchall()]
-
-    if "is_pinned" not in columns:
-        conn.execute("ALTER TABLE chats ADD COLUMN is_pinned INTEGER DEFAULT 0")
-
-    # Add model and provider columns for per-chat model selection
-    if "model" not in columns:
-        conn.execute("ALTER TABLE chats ADD COLUMN model TEXT")
-    if "provider" not in columns:
-        conn.execute("ALTER TABLE chats ADD COLUMN provider TEXT")
-
-    # Migrate existing LLM config from configurations table to llm_providers
-    # Check if llm_providers table has any data
-    cursor = conn.execute("SELECT COUNT(*) FROM llm_providers")
-    provider_count = cursor.fetchone()[0]
-
-    if provider_count == 0:
-        # Check if there's existing LLM config in configurations table
-        cursor = conn.execute(
-            "SELECT value FROM configurations WHERE key = 'llm'"
-        )
-        row = cursor.fetchone()
-
-        if row:
-            try:
-                llm_config = json.loads(row[0])
-                provider_name = llm_config.get("provider", "ollama")
-                base_url = llm_config.get("base_url", "http://localhost:11434/v1")
-                api_key = llm_config.get("api_key", "")
-                model = llm_config.get("model", "")
-
-                # Insert into llm_providers as default
-                conn.execute(
-                    """
-                    INSERT INTO llm_providers (id, name, base_url, api_key, model, is_default)
-                    VALUES (?, ?, ?, ?, ?, 1)
-                    """,
-                    (str(uuid.uuid4()), provider_name, base_url, api_key, model),
-                )
-
-                # Delete the legacy configuration entry
-                conn.execute("DELETE FROM configurations WHERE key = 'llm'")
-            except (json.JSONDecodeError, KeyError):
-                pass
+    try:
+        # Run all pending migrations
+        migrations_run = run_migrations(conn)
+        if migrations_run > 0:
+            print(f"Database initialized with {migrations_run} migration(s)")
+    finally:
+        conn.close()
 
 
 @contextmanager

--- a/backend/database/migrations/20241201000000_initial_schema.py
+++ b/backend/database/migrations/20241201000000_initial_schema.py
@@ -1,0 +1,87 @@
+"""Initial database schema migration.
+
+This creates the base tables that existed before the migration system.
+"""
+
+import sqlite3
+
+VERSION = "20241201000000"
+DESCRIPTION = "Create initial schema (chats, messages, tags, transcripts, configurations, mcp_servers)"
+
+
+def up(conn: sqlite3.Connection) -> None:
+    """Apply the migration."""
+    conn.executescript("""
+        -- Chats table
+        CREATE TABLE IF NOT EXISTS chats (
+            id TEXT PRIMARY KEY,
+            title TEXT NOT NULL DEFAULT 'New Chat',
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            is_archived INTEGER DEFAULT 0
+        );
+
+        -- Chat tags
+        CREATE TABLE IF NOT EXISTS chat_tags (
+            id TEXT PRIMARY KEY,
+            name TEXT UNIQUE NOT NULL,
+            color TEXT DEFAULT '#6B7280'
+        );
+
+        -- Chat tag assignments (many-to-many)
+        CREATE TABLE IF NOT EXISTS chat_tag_assignments (
+            chat_id TEXT NOT NULL,
+            tag_id TEXT NOT NULL,
+            PRIMARY KEY (chat_id, tag_id),
+            FOREIGN KEY (chat_id) REFERENCES chats(id) ON DELETE CASCADE,
+            FOREIGN KEY (tag_id) REFERENCES chat_tags(id) ON DELETE CASCADE
+        );
+
+        -- Messages table
+        CREATE TABLE IF NOT EXISTS messages (
+            id TEXT PRIMARY KEY,
+            chat_id TEXT NOT NULL,
+            role TEXT NOT NULL CHECK(role IN ('user', 'assistant', 'system')),
+            content TEXT NOT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            artifact_type TEXT,
+            artifact_data JSON,
+            FOREIGN KEY (chat_id) REFERENCES chats(id) ON DELETE CASCADE
+        );
+        CREATE INDEX IF NOT EXISTS idx_messages_chat_id ON messages(chat_id);
+        CREATE INDEX IF NOT EXISTS idx_messages_created_at ON messages(created_at);
+
+        -- Transcripts table (YouTube video transcripts)
+        CREATE TABLE IF NOT EXISTS transcripts (
+            id TEXT PRIMARY KEY,
+            video_id TEXT UNIQUE NOT NULL,
+            video_url TEXT NOT NULL,
+            video_title TEXT,
+            language_code TEXT DEFAULT 'en',
+            is_generated INTEGER DEFAULT 0,
+            raw_transcript JSON,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE INDEX IF NOT EXISTS idx_transcripts_video_id ON transcripts(video_id);
+
+        -- Configurations table
+        CREATE TABLE IF NOT EXISTS configurations (
+            key TEXT PRIMARY KEY,
+            value JSON NOT NULL,
+            category TEXT DEFAULT 'general'
+        );
+
+        -- MCP Servers table
+        CREATE TABLE IF NOT EXISTS mcp_servers (
+            id TEXT PRIMARY KEY,
+            name TEXT UNIQUE NOT NULL,
+            transport_type TEXT NOT NULL CHECK(transport_type IN ('stdio', 'sse')),
+            command TEXT,
+            args JSON,
+            url TEXT,
+            env JSON,
+            enabled INTEGER DEFAULT 1,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );
+    """)

--- a/backend/database/migrations/20241210000000_add_is_pinned_to_chats.py
+++ b/backend/database/migrations/20241210000000_add_is_pinned_to_chats.py
@@ -1,0 +1,16 @@
+"""Add is_pinned column to chats table."""
+
+import sqlite3
+
+VERSION = "20241210000000"
+DESCRIPTION = "Add is_pinned column to chats table"
+
+
+def up(conn: sqlite3.Connection) -> None:
+    """Apply the migration."""
+    # Check if column already exists (for existing databases)
+    cursor = conn.execute("PRAGMA table_info(chats)")
+    columns = [row[1] for row in cursor.fetchall()]
+
+    if "is_pinned" not in columns:
+        conn.execute("ALTER TABLE chats ADD COLUMN is_pinned INTEGER DEFAULT 0")

--- a/backend/database/migrations/20241215000000_create_llm_providers.py
+++ b/backend/database/migrations/20241215000000_create_llm_providers.py
@@ -1,0 +1,58 @@
+"""Create llm_providers table for multi-provider LLM support."""
+
+import json
+import sqlite3
+import uuid
+
+VERSION = "20241215000000"
+DESCRIPTION = "Create llm_providers table"
+
+
+def up(conn: sqlite3.Connection) -> None:
+    """Apply the migration."""
+    # Create the llm_providers table
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS llm_providers (
+            id TEXT PRIMARY KEY,
+            name TEXT UNIQUE NOT NULL,
+            base_url TEXT NOT NULL,
+            api_key TEXT,
+            model TEXT,
+            is_default INTEGER DEFAULT 0,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+    """)
+
+    # Migrate existing LLM config from configurations table if it exists
+    cursor = conn.execute("SELECT COUNT(*) FROM llm_providers")
+    provider_count = cursor.fetchone()[0]
+
+    if provider_count == 0:
+        # Check if there's existing LLM config in configurations table
+        cursor = conn.execute(
+            "SELECT value FROM configurations WHERE key = 'llm'"
+        )
+        row = cursor.fetchone()
+
+        if row:
+            try:
+                llm_config = json.loads(row[0])
+                provider_name = llm_config.get("provider", "ollama")
+                base_url = llm_config.get("base_url", "http://localhost:11434/v1")
+                api_key = llm_config.get("api_key", "")
+                model = llm_config.get("model", "")
+
+                # Insert into llm_providers as default
+                conn.execute(
+                    """
+                    INSERT INTO llm_providers (id, name, base_url, api_key, model, is_default)
+                    VALUES (?, ?, ?, ?, ?, 1)
+                    """,
+                    (str(uuid.uuid4()), provider_name, base_url, api_key, model),
+                )
+
+                # Delete the legacy configuration entry
+                conn.execute("DELETE FROM configurations WHERE key = 'llm'")
+            except (json.JSONDecodeError, KeyError):
+                pass

--- a/backend/database/migrations/20241216000000_add_model_provider_to_chats.py
+++ b/backend/database/migrations/20241216000000_add_model_provider_to_chats.py
@@ -1,0 +1,19 @@
+"""Add model and provider columns to chats table for per-chat model selection."""
+
+import sqlite3
+
+VERSION = "20241216000000"
+DESCRIPTION = "Add model and provider columns to chats table"
+
+
+def up(conn: sqlite3.Connection) -> None:
+    """Apply the migration."""
+    # Check existing columns
+    cursor = conn.execute("PRAGMA table_info(chats)")
+    columns = [row[1] for row in cursor.fetchall()]
+
+    if "model" not in columns:
+        conn.execute("ALTER TABLE chats ADD COLUMN model TEXT")
+
+    if "provider" not in columns:
+        conn.execute("ALTER TABLE chats ADD COLUMN provider TEXT")

--- a/backend/database/migrations/__init__.py
+++ b/backend/database/migrations/__init__.py
@@ -1,0 +1,1 @@
+"""Database migrations package."""

--- a/backend/database/migrator.py
+++ b/backend/database/migrator.py
@@ -1,0 +1,135 @@
+"""Database migration system similar to Rails migrations.
+
+This module provides a versioned migration system that:
+1. Tracks which migrations have been run in a schema_migrations table
+2. Runs pending migrations in order by version number
+3. Supports both up (apply) migrations
+4. Each migration is a Python file with a version timestamp and description
+
+Usage:
+    from database.migrator import run_migrations
+    run_migrations(connection)
+
+Migration files should be named like:
+    20231215120000_create_chats_table.py
+    20231216100000_add_is_pinned_to_chats.py
+
+Each migration file should contain:
+    VERSION = "20231215120000"
+    DESCRIPTION = "Create chats table"
+
+    def up(conn: sqlite3.Connection) -> None:
+        conn.execute('''CREATE TABLE ...''')
+"""
+
+import importlib
+import sqlite3
+from pathlib import Path
+from typing import List, Tuple
+
+
+MIGRATIONS_DIR = Path(__file__).parent / "migrations"
+
+
+def ensure_schema_migrations_table(conn: sqlite3.Connection) -> None:
+    """Create the schema_migrations table if it doesn't exist."""
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS schema_migrations (
+            version TEXT PRIMARY KEY,
+            description TEXT,
+            applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+    """)
+    conn.commit()
+
+
+def get_applied_migrations(conn: sqlite3.Connection) -> set[str]:
+    """Get the set of already applied migration versions."""
+    cursor = conn.execute("SELECT version FROM schema_migrations ORDER BY version")
+    return {row[0] for row in cursor.fetchall()}
+
+
+def get_pending_migrations(conn: sqlite3.Connection) -> List[Tuple[str, str, Path]]:
+    """Get list of pending migrations as (version, description, path) tuples."""
+    applied = get_applied_migrations(conn)
+    pending = []
+
+    if not MIGRATIONS_DIR.exists():
+        return pending
+
+    for migration_file in sorted(MIGRATIONS_DIR.glob("*.py")):
+        if migration_file.name == "__init__.py":
+            continue
+
+        # Extract version from filename (e.g., 20231215120000_create_chats.py)
+        version = migration_file.stem.split("_")[0]
+
+        if version not in applied:
+            # Import the module to get description
+            module_name = f"database.migrations.{migration_file.stem}"
+            try:
+                module = importlib.import_module(module_name)
+                description = getattr(module, "DESCRIPTION", migration_file.stem)
+                pending.append((version, description, migration_file))
+            except ImportError as e:
+                print(f"Warning: Could not import migration {migration_file.name}: {e}")
+
+    return sorted(pending, key=lambda x: x[0])
+
+
+def run_migration(conn: sqlite3.Connection, version: str, description: str, path: Path) -> None:
+    """Run a single migration."""
+    module_name = f"database.migrations.{path.stem}"
+    module = importlib.import_module(module_name)
+
+    if not hasattr(module, "up"):
+        raise ValueError(f"Migration {path.name} does not have an 'up' function")
+
+    print(f"  Running migration {version}: {description}")
+
+    # Run the migration
+    module.up(conn)
+
+    # Record that migration was applied
+    conn.execute(
+        "INSERT INTO schema_migrations (version, description) VALUES (?, ?)",
+        (version, description)
+    )
+    conn.commit()
+
+
+def run_migrations(conn: sqlite3.Connection) -> int:
+    """Run all pending migrations.
+
+    Returns:
+        Number of migrations that were run.
+    """
+    ensure_schema_migrations_table(conn)
+
+    pending = get_pending_migrations(conn)
+
+    if not pending:
+        return 0
+
+    print(f"Running {len(pending)} pending migration(s)...")
+
+    for version, description, path in pending:
+        run_migration(conn, version, description, path)
+
+    print(f"Completed {len(pending)} migration(s).")
+    return len(pending)
+
+
+def get_migration_status(conn: sqlite3.Connection) -> dict:
+    """Get the current migration status."""
+    ensure_schema_migrations_table(conn)
+
+    applied = get_applied_migrations(conn)
+    pending = get_pending_migrations(conn)
+
+    return {
+        "applied_count": len(applied),
+        "pending_count": len(pending),
+        "applied_versions": sorted(applied),
+        "pending_versions": [v for v, _, _ in pending],
+    }


### PR DESCRIPTION
- Create versioned migration system with schema_migrations tracking table
- Add migrator.py with automatic pending migration detection and execution
- Convert existing schema to 4 versioned migrations (initial, is_pinned, llm_providers, chat model/provider)
- Simplify connection.py to use migration system on startup
- Update CLAUDE.md with comprehensive migration documentation
- Add .cursorrules for Cursor IDE with migration guidelines

Migrations run automatically on backend startup, ensuring database schema stays in sync across deployments without manual intervention.