### PR TITLE
feat: Add unified Kamal deployment with pre-deploy hook

### DIFF
--- a/.kamal/hooks/pre-deploy
+++ b/.kamal/hooks/pre-deploy
@@ -1,0 +1,57 @@
+#!/bin/bash
+#
+# Kamal pre-deploy hook
+# This runs before the main app deployment
+# It builds and pushes the backend image, then restarts the backend accessory
+#
+
+set -e
+
+echo "==> Pre-deploy: Building and deploying backend..."
+
+BACKEND_IMAGE="ghcr.io/przbadu/localmind-backend:latest"
+PROJECT_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+# Build backend image
+echo "==> Building backend Docker image..."
+docker build -t "$BACKEND_IMAGE" "$PROJECT_ROOT/backend"
+
+# Push backend image
+echo "==> Pushing backend image to registry..."
+docker push "$BACKEND_IMAGE"
+
+# Pull new image on server and restart container
+echo "==> Deploying backend to server..."
+ssh root@192.168.1.173 "
+  docker pull $BACKEND_IMAGE
+
+  # Stop and remove existing container if it exists
+  docker stop localmind-backend 2>/dev/null || true
+  docker rm localmind-backend 2>/dev/null || true
+
+  # Start new container
+  docker run -d \
+    --name localmind-backend \
+    --restart unless-stopped \
+    --add-host host.docker.internal:host-gateway \
+    -p 8001:8001 \
+    -v /var/data/localmind:/app/data \
+    -e PYTHONPATH=/app \
+    -e DATABASE_PATH=/app/data/local_mind.db \
+    -e 'OLLAMA_HOST=http://host.docker.internal:11434' \
+    $BACKEND_IMAGE \
+    uvicorn main:app --host 0.0.0.0 --port 8001
+"
+
+# Wait for backend to be healthy
+echo "==> Waiting for backend health check..."
+for i in {1..12}; do
+    if ssh root@192.168.1.173 "curl -sf http://localhost:8001/health" > /dev/null 2>&1; then
+        echo "==> Backend is healthy!"
+        exit 0
+    fi
+    echo "  Waiting for backend... (attempt $i/12)"
+    sleep 5
+done
+
+echo "==> Warning: Backend health check timed out, continuing with frontend deploy..."

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+READ @CLAUDE.md for project memory

--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ cp .kamal/secrets.example .kamal/secrets
 kamal setup
 
 # Subsequent deployments
-kamal deploy
+set -a && source .env && set +a && kamal deploy
 ```
 
 The app will be available at `http://your-server-ip:3000`

--- a/bin/deploy
+++ b/bin/deploy
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# LocalMind Deployment Script
+#
+# This is a convenience wrapper around `kamal deploy`.
+# The actual deployment logic is in .kamal/hooks/pre-deploy
+#
+# Usage: ./bin/deploy
+#
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+echo "╔════════════════════════════════════════╗"
+echo "║     LocalMind Deployment               ║"
+echo "╚════════════════════════════════════════╝"
+echo ""
+echo "Running kamal deploy..."
+echo "This will:"
+echo "  1. Build and push backend image (pre-deploy hook)"
+echo "  2. Deploy backend container"
+echo "  3. Build and push frontend image"
+echo "  4. Deploy frontend container"
+echo ""
+
+kamal deploy
+
+echo ""
+echo "✓ Deployment complete!"
+echo "  Frontend: http://192.168.1.173"
+echo "  Backend:  http://192.168.1.173:8001"

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -1,6 +1,15 @@
 # Kamal deployment configuration for LocalMind
 # Documentation: https://kamal-deploy.org/docs/configuration/
 #
+# Deployment: Just run `kamal deploy` - it handles both frontend and backend!
+#
+# The pre-deploy hook (.kamal/hooks/pre-deploy) automatically:
+#   1. Builds the backend Docker image
+#   2. Pushes it to the registry
+#   3. Deploys and restarts the backend container
+#   4. Waits for health check
+#   5. Then Kamal deploys the frontend
+#
 # Quick Start:
 #   1. Copy .env.example to .env and configure your values
 #   2. Copy .kamal/secrets.example to .kamal/secrets
@@ -54,25 +63,8 @@ env:
 volumes:
   - /var/data/localmind:/app/data
 
-# Backend service as an accessory
-accessories:
-  backend:
-    image: ghcr.io/przbadu/localmind-backend
-    host: 192.168.1.173
-    port: 8001
-    cmd: uvicorn main:app --host 0.0.0.0 --port 8001
-    env:
-      clear:
-        PYTHONPATH: /app
-        DATABASE_PATH: /app/data/local_mind.db
-        # Ollama running on host machine
-        OLLAMA_HOST: http://host.docker.internal:11434
-      secret:
-        - LLM_API_KEY
-    volumes:
-      - /var/data/localmind:/app/data
-    options:
-      add-host: host.docker.internal:host-gateway
+# Note: Backend is deployed via pre-deploy hook (.kamal/hooks/pre-deploy)
+# This ensures the backend image is always built and deployed with the frontend
 
 # Build configuration
 builder:


### PR DESCRIPTION

#18 
- Add .kamal/hooks/pre-deploy to build and deploy backend automatically
- Remove accessory config, backend now deployed via hook for consistency
- Update deploy.yml with simplified configuration
- Add bin/deploy convenience script
- Update CLAUDE.md with deployment documentation

Now `kamal deploy` handles both frontend and backend in one command. The pre-deploy hook builds the backend image, pushes to registry, deploys the container, and waits for health check before proceeding.