### PR TITLE
feat: Add optional Clerk authentication with configurable modes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,3 +39,8 @@ BACKEND_PORT=52817
 # For local development: ./data/local_mind.db
 # For Docker/Kamal: /app/data/local_mind.db
 DATABASE_PATH=./data/local_mind.db
+
+# ----- Authentication (Clerk) -----
+# Get your publishable key from: https://dashboard.clerk.com/last-active?path=api-keys
+# Only required if auth.enabled is true in app.config.json
+VITE_CLERK_PUBLISHABLE_KEY=pk_test_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/app.config.json
+++ b/app.config.json
@@ -62,5 +62,9 @@
     "enable_youtube": true,
     "enable_mcp": true,
     "enable_offline_mode": true
+  },
+  "auth": {
+    "enabled": false,
+    "allow_signup": false
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "local-mind",
       "dependencies": {
+        "@clerk/clerk-react": "^5.59.2",
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-aspect-ratio": "^1.1.7",
@@ -120,6 +121,10 @@
     "@babel/traverse": ["@babel/traverse@7.28.4", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/generator": "^7.28.3", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.28.4", "@babel/template": "^7.27.2", "@babel/types": "^7.28.4", "debug": "^4.3.1" } }, "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ=="],
 
     "@babel/types": ["@babel/types@7.28.4", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1" } }, "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q=="],
+
+    "@clerk/clerk-react": ["@clerk/clerk-react@5.59.2", "", { "dependencies": { "@clerk/shared": "^3.41.1", "tslib": "2.8.1" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" } }, "sha512-vFZ4LWPenbNnui4GqGGkicH/3SL7KhS9egTMv/m0Dj/sS7mUgmLqAFpqWkhbzN8s8/rybuvJsMyIU7M0kx8+Cw=="],
+
+    "@clerk/shared": ["@clerk/shared@3.41.1", "", { "dependencies": { "csstype": "3.1.3", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.5", "std-env": "^3.9.0", "swr": "2.3.4" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-BCbT7Xodk2rndA2nV/lW8X5LMNTvFP5UG2wNN9cYuAcTaI6hYZP18/z2zef2gG4xIrK7WAEjGVzHscikqNtzFQ=="],
 
     "@date-fns/tz": ["@date-fns/tz@1.4.1", "", {}, "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA=="],
 
@@ -609,6 +614,8 @@
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
+    "glob-to-regexp": ["glob-to-regexp@0.4.1", "", {}, "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="],
+
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
     "hast-util-is-element": ["hast-util-is-element@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g=="],
@@ -656,6 +663,8 @@
     "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
 
     "jiti": ["jiti@1.21.7", "", { "bin": { "jiti": "bin/jiti.js" } }, "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A=="],
+
+    "js-cookie": ["js-cookie@3.0.5", "", {}, "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -927,6 +936,8 @@
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
 
+    "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
     "string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
     "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
@@ -944,6 +955,8 @@
     "sucrase": ["sucrase@3.35.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.2", "commander": "^4.0.0", "glob": "^10.3.10", "lines-and-columns": "^1.1.6", "mz": "^2.7.0", "pirates": "^4.0.1", "ts-interface-checker": "^0.1.9" }, "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" } }, "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA=="],
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
+
+    "swr": ["swr@2.3.4", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg=="],
 
     "tailwind-merge": ["tailwind-merge@3.3.1", "", {}, "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g=="],
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,207 @@
+# Authentication Setup
+
+LocalMind supports optional authentication using [Clerk](https://clerk.com/). Authentication is **disabled by default**, making it easy to run the app locally without any setup.
+
+## Quick Reference
+
+| Use Case | `auth.enabled` | `auth.allow_signup` | Clerk Key Required |
+|----------|----------------|---------------------|-------------------|
+| Local/Desktop (no auth) | `false` | N/A | No |
+| Private server (sign-in only) | `true` | `false` | Yes |
+| Public deployment (sign-in + sign-up) | `true` | `true` | Yes |
+
+## Configuration Options
+
+Authentication is configured in `app.config.json`:
+
+```json
+{
+  "auth": {
+    "enabled": false,
+    "allow_signup": false
+  }
+}
+```
+
+### Options
+
+- **`enabled`**: Enable or disable authentication entirely
+  - `false` (default): No authentication, app is accessible to anyone
+  - `true`: Requires Clerk authentication to access the app
+
+- **`allow_signup`**: Control whether new users can register
+  - `false`: Only existing users can sign in (invite-only)
+  - `true`: Anyone can create an account
+
+## Setup Scenarios
+
+### Scenario 1: No Authentication (Default)
+
+For local development or desktop app usage where authentication is not needed.
+
+**Configuration:**
+```json
+{
+  "auth": {
+    "enabled": false,
+    "allow_signup": false
+  }
+}
+```
+
+No additional setup required. The app works immediately.
+
+### Scenario 2: Sign-in Only (Private Server)
+
+For personal deployments where only you (or invited users) should have access.
+
+**Step 1: Create a Clerk Application**
+
+1. Go to [Clerk Dashboard](https://dashboard.clerk.com/)
+2. Create a new application
+3. Navigate to **API Keys** page
+4. Copy your **Publishable Key**
+
+**Step 2: Configure Environment**
+
+Create `.env.local` in the project root:
+
+```bash
+VITE_CLERK_PUBLISHABLE_KEY=pk_test_your_key_here
+```
+
+**Step 3: Update Configuration**
+
+In `app.config.json`:
+
+```json
+{
+  "auth": {
+    "enabled": true,
+    "allow_signup": false
+  }
+}
+```
+
+**Step 4: Add Users in Clerk Dashboard**
+
+Since sign-up is disabled, you need to manually add users:
+
+1. Go to Clerk Dashboard > **Users**
+2. Click **Create user**
+3. Enter email and password
+4. The user can now sign in to your app
+
+### Scenario 3: Public Registration (Open Access)
+
+For deployments where anyone can create an account.
+
+**Step 1: Create a Clerk Application**
+
+Same as Scenario 2.
+
+**Step 2: Configure Environment**
+
+Create `.env.local`:
+
+```bash
+VITE_CLERK_PUBLISHABLE_KEY=pk_test_your_key_here
+```
+
+**Step 3: Update Configuration**
+
+In `app.config.json`:
+
+```json
+{
+  "auth": {
+    "enabled": true,
+    "allow_signup": true
+  }
+}
+```
+
+Users will see both "Sign in" and "Sign up" options.
+
+## Docker/Kamal Deployment
+
+When deploying with Docker or Kamal, pass the environment variable:
+
+### Docker Compose
+
+Add to `docker-compose.yml`:
+
+```yaml
+services:
+  frontend:
+    environment:
+      - VITE_CLERK_PUBLISHABLE_KEY=${VITE_CLERK_PUBLISHABLE_KEY}
+```
+
+Then set in `.env`:
+
+```bash
+VITE_CLERK_PUBLISHABLE_KEY=pk_live_your_production_key
+```
+
+### Kamal
+
+Add to `.kamal/secrets`:
+
+```bash
+VITE_CLERK_PUBLISHABLE_KEY=pk_live_your_production_key
+```
+
+Update `config/deploy.yml` to include the secret:
+
+```yaml
+env:
+  secret:
+    - VITE_CLERK_PUBLISHABLE_KEY
+```
+
+## Troubleshooting
+
+### "Authentication Configuration Error" Message
+
+This appears when `auth.enabled` is `true` but `VITE_CLERK_PUBLISHABLE_KEY` is not set.
+
+**Solution:** Either:
+- Set the environment variable in `.env.local`
+- Or disable auth by setting `auth.enabled` to `false`
+
+### Sign-up Button Not Appearing
+
+If `allow_signup` is `false`, the sign-up option is hidden. This is intentional for private deployments.
+
+**Solution:** Set `auth.allow_signup` to `true` if you want public registration.
+
+### User Cannot Sign In
+
+1. Verify the user exists in Clerk Dashboard
+2. Check that `VITE_CLERK_PUBLISHABLE_KEY` matches your Clerk application
+3. Ensure you're using the correct environment (test vs. production keys)
+
+## Security Notes
+
+1. **Never commit `.env.local`** - It's already in `.gitignore`
+2. **Use production keys for production** - Clerk provides separate test and live keys
+3. **Clerk handles security** - Passwords are never stored in LocalMind; Clerk manages all authentication securely
+
+## Architecture
+
+The authentication flow is handled by `ClerkProviderWrapper`:
+
+```
+ClerkProviderWrapper
+├── auth.enabled = false → Render app directly (no auth)
+├── auth.enabled = true, no key → Show configuration error
+└── auth.enabled = true, has key → ClerkProvider
+    ├── SignedIn → Render app
+    └── SignedOut → Show sign-in form
+```
+
+The `UserButton` component appears in the header when a user is signed in, providing:
+- User profile management
+- Sign out functionality
+- Account settings (via Clerk's hosted UI)

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "tauri:build": "bun run build && bun tauri build"
   },
   "dependencies": {
+    "@clerk/clerk-react": "^5.59.2",
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-aspect-ratio": "^1.1.7",

--- a/src/components/app-header.tsx
+++ b/src/components/app-header.tsx
@@ -1,6 +1,8 @@
+import { SignedIn, UserButton } from "@clerk/clerk-react"
 import { ThemeToggle } from "@/components/theme-toggle"
 import { useHeaderStore } from "@/stores/useHeaderStore"
 import { SidebarTrigger } from "@/components/ui/sidebar"
+import { AUTH_ENABLED } from "@/config/app-config"
 
 export function AppHeader() {
   const title = useHeaderStore((state) => state.title)
@@ -13,10 +15,18 @@ export function AppHeader() {
       </div>
 
       <div className="flex items-center gap-2">
-        {/* <Button variant="ghost" size="icon" className="h-8 w-8">
-          <Bell className="h-4 w-4" />
-        </Button> */}
         <ThemeToggle />
+        {AUTH_ENABLED && (
+          <SignedIn>
+            <UserButton
+              appearance={{
+                elements: {
+                  avatarBox: "h-8 w-8",
+                },
+              }}
+            />
+          </SignedIn>
+        )}
       </div>
     </header>
   )

--- a/src/components/clerk-provider-wrapper.tsx
+++ b/src/components/clerk-provider-wrapper.tsx
@@ -1,0 +1,61 @@
+import { ClerkProvider, SignedIn, SignedOut, SignIn } from "@clerk/clerk-react";
+import { AUTH_ENABLED, SIGNUP_ALLOWED } from "@/config/app-config";
+
+const PUBLISHABLE_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
+
+interface ClerkProviderWrapperProps {
+  children: React.ReactNode;
+}
+
+function AuthGate({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <SignedIn>{children}</SignedIn>
+      <SignedOut>
+        <div className="min-h-screen flex items-center justify-center bg-background">
+          <div className="w-full max-w-md p-4">
+            <SignIn
+              appearance={{
+                elements: {
+                  rootBox: "w-full",
+                  card: "shadow-lg",
+                },
+              }}
+              signUpUrl={SIGNUP_ALLOWED ? undefined : ""}
+            />
+          </div>
+        </div>
+      </SignedOut>
+    </>
+  );
+}
+
+export function ClerkProviderWrapper({ children }: ClerkProviderWrapperProps) {
+  // If auth is not enabled, just render children directly
+  if (!AUTH_ENABLED) {
+    return <>{children}</>;
+  }
+
+  // Auth is enabled but no publishable key - show error
+  if (!PUBLISHABLE_KEY) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-background">
+        <div className="text-center p-8 max-w-md">
+          <h1 className="text-xl font-semibold text-destructive mb-4">
+            Authentication Configuration Error
+          </h1>
+          <p className="text-muted-foreground">
+            Authentication is enabled but VITE_CLERK_PUBLISHABLE_KEY is not set.
+            Please add your Clerk publishable key to .env.local file.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <ClerkProvider publishableKey={PUBLISHABLE_KEY} afterSignOutUrl="/">
+      <AuthGate>{children}</AuthGate>
+    </ClerkProvider>
+  );
+}

--- a/src/config/app-config.ts
+++ b/src/config/app-config.ts
@@ -66,6 +66,10 @@ export interface AppConfig {
     enable_mcp: boolean;
     enable_offline_mode: boolean;
   };
+  auth: {
+    enabled: boolean;
+    allow_signup: boolean;
+  };
 }
 
 class ConfigLoader {
@@ -146,6 +150,14 @@ class ConfigLoader {
   get databasePath(): string {
     return this.config.storage.database_path;
   }
+
+  get isAuthEnabled(): boolean {
+    return this.config.auth.enabled;
+  }
+
+  get isSignupAllowed(): boolean {
+    return this.config.auth.allow_signup;
+  }
 }
 
 // Create singleton instance
@@ -163,3 +175,5 @@ export const OLLAMA_PORT = appConfig.ollamaPort;
 export const EMBEDDING_MODEL = appConfig.embeddingModel;
 export const YOUTUBE_ENABLED = appConfig.isYouTubeEnabled;
 export const MCP_ENABLED = appConfig.isMCPEnabled;
+export const AUTH_ENABLED = appConfig.isAuthEnabled;
+export const SIGNUP_ALLOWED = appConfig.isSignupAllowed;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,8 +1,14 @@
+import { StrictMode } from "react";
 import ReactDOM from "react-dom/client";
 
 import "./index.css";
 import App from "./App";
+import { ClerkProviderWrapper } from "@/components/clerk-provider-wrapper";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
- <App />
+  <StrictMode>
+    <ClerkProviderWrapper>
+      <App />
+    </ClerkProviderWrapper>
+  </StrictMode>
 );


### PR DESCRIPTION
- Add @clerk/clerk-react for authentication support
- Create ClerkProviderWrapper with three modes:
  - No auth (default): app accessible without setup
  - Sign-in only: for private deployments
  - Open registration: for public deployments
- Add auth config to app.config.json (enabled, allow_signup)
- Display UserButton in header when authenticated
- Add comprehensive authentication documentation