### PR TITLE
fix: Use --no-cache by default for backend Docker builds

### DIFF
--- a/.kamal/hooks/pre-deploy
+++ b/.kamal/hooks/pre-deploy
@@ -4,6 +4,10 @@
 # This runs before the main app deployment
 # It builds and pushes the backend image, then restarts the backend accessory
 #
+# Build modes:
+#   Default: --no-cache (reliable, prevents stale code issues)
+#   With DEPLOY_USE_CACHE=true: uses Docker cache (faster)
+#
 
 set -e
 
@@ -18,9 +22,18 @@ GIT_COMMIT=$(git -C "$PROJECT_ROOT" rev-parse --short HEAD 2>/dev/null || echo "
 
 echo "==> Version: $APP_VERSION (commit: $GIT_COMMIT)"
 
+# Determine cache mode
+if [ "$DEPLOY_USE_CACHE" = "true" ]; then
+    echo "==> Building backend Docker image (with cache)..."
+    CACHE_FLAG=""
+else
+    echo "==> Building backend Docker image (--no-cache for fresh build)..."
+    CACHE_FLAG="--no-cache"
+fi
+
 # Build backend image with version info
-echo "==> Building backend Docker image..."
 docker build \
+  $CACHE_FLAG \
   --build-arg APP_VERSION="$APP_VERSION" \
   --build-arg GIT_COMMIT="$GIT_COMMIT" \
   -t "$BACKEND_IMAGE" \

--- a/bin/deploy
+++ b/bin/deploy
@@ -5,16 +5,42 @@
 # This is a convenience wrapper around `kamal deploy`.
 # The actual deployment logic is in .kamal/hooks/pre-deploy
 #
-# Usage: ./bin/deploy
+# Usage:
+#   ./bin/deploy           # Default: builds with --no-cache (reliable)
+#   ./bin/deploy --cached  # Uses Docker cache (faster, for frontend-only changes)
 #
 
 set -e
 
 cd "$(dirname "$0")/.."
 
+# Parse arguments
+USE_CACHE=false
+for arg in "$@"; do
+    case $arg in
+        --cached)
+            USE_CACHE=true
+            shift
+            ;;
+    esac
+done
+
+# Export for pre-deploy hook to use
+export DEPLOY_USE_CACHE="$USE_CACHE"
+
 echo "╔════════════════════════════════════════╗"
 echo "║     LocalMind Deployment               ║"
 echo "╚════════════════════════════════════════╝"
+echo ""
+
+if [ "$USE_CACHE" = true ]; then
+    echo "Mode: CACHED (faster, uses Docker cache)"
+    echo "      Use this for frontend-only changes"
+else
+    echo "Mode: FRESH (--no-cache, reliable)"
+    echo "      Use --cached flag for faster builds"
+fi
+
 echo ""
 echo "Running kamal deploy..."
 echo "This will:"


### PR DESCRIPTION
Prevents stale code issues caused by Docker layer caching during deployment. The pre-deploy hook now always builds with --no-cache for reliability.

- Add --cached flag to bin/deploy for faster frontend-only deploys
- Update pre-deploy hook to support DEPLOY_USE_CACHE environment var
- Add comprehensive deployment troubleshooting docs:
  - Docker cache issues diagnosis and resolution
  - Server disk space cleanup
  - Backend health check port mismatch explanation
  - MCP server startup timeout solutions