### PR TITLE
fix: Prevent document deletion and improve attachment handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,20 @@ Local Mind is a desktop application that lets you:
 - **[uv](https://docs.astral.sh/uv/)** - Fast Python package manager
 - **LLM Server** - [Ollama](https://ollama.ai/), LlamaCpp, or any OpenAI-compatible endpoint
 
+#### Linux System Dependencies
+
+On Fedora/RHEL-based systems:
+```bash
+sudo dnf install python3-devel gcc
+```
+
+On Debian/Ubuntu-based systems:
+```bash
+sudo apt install python3-dev build-essential
+```
+
+These are required to build Python packages like NumPy that compile native extensions.
+
 ### Quick Start
 
 ```bash

--- a/src/components/chat/DocumentViewer.tsx
+++ b/src/components/chat/DocumentViewer.tsx
@@ -2,13 +2,102 @@ import { useState, useEffect } from "react"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
-import { Loader2, AlertCircle, Paperclip, Eye, ExternalLink, Image as ImageIcon, Music } from "lucide-react"
+import {
+    Loader2,
+    AlertCircle,
+    Paperclip,
+    Eye,
+    ExternalLink,
+    Image as ImageIcon,
+    Music,
+    FileText,
+    FileCode,
+    Table,
+    Presentation,
+    X,
+    type LucideIcon
+} from "lucide-react"
 import { MarkdownRenderer } from "@/components/MarkdownRenderer"
 import { documentService, type Document, type DocumentChunk } from "@/services/document-service"
 import { Badge } from "@/components/ui/badge"
 import { formatFileSize } from "@/components/chat/DocumentAttachment"
 import { API_BASE_URL } from "@/config/app-config"
-import { X } from "lucide-react"
+
+/**
+ * Get icon and color based on filename extension.
+ * Used for displaying appropriate file type icons in chat messages and document viewer.
+ */
+export function getFileIcon(filename: string): { Icon: LucideIcon; color: string } {
+    const ext = filename.toLowerCase().split('.').pop() || ''
+
+    switch (ext) {
+        // PDF
+        case 'pdf':
+            return { Icon: FileText, color: 'text-red-500' }
+
+        // Word documents
+        case 'doc':
+        case 'docx':
+            return { Icon: FileText, color: 'text-blue-500' }
+
+        // PowerPoint
+        case 'ppt':
+        case 'pptx':
+            return { Icon: Presentation, color: 'text-orange-500' }
+
+        // Excel/Spreadsheets
+        case 'xls':
+        case 'xlsx':
+        case 'xlsb':
+        case 'csv':
+            return { Icon: Table, color: 'text-green-500' }
+
+        // Images
+        case 'png':
+        case 'jpg':
+        case 'jpeg':
+        case 'gif':
+        case 'webp':
+        case 'tiff':
+        case 'bmp':
+        case 'svg':
+            return { Icon: ImageIcon, color: 'text-purple-500' }
+
+        // Audio
+        case 'mp3':
+        case 'wav':
+        case 'ogg':
+        case 'm4a':
+        case 'flac':
+        case 'aac':
+            return { Icon: Music, color: 'text-pink-500' }
+
+        // HTML/Code
+        case 'html':
+        case 'htm':
+        case 'xml':
+            return { Icon: FileCode, color: 'text-yellow-500' }
+
+        // Text/Markdown
+        case 'txt':
+        case 'md':
+        case 'rtf':
+        case 'adoc':
+            return { Icon: FileText, color: 'text-gray-500' }
+
+        // Default
+        default:
+            return { Icon: Paperclip, color: 'text-blue-500' }
+    }
+}
+
+/**
+ * Check if a file is an HTML document based on mime type or extension.
+ */
+function isHtmlDocument(mimeType: string, filename: string): boolean {
+    const ext = filename.toLowerCase().split('.').pop() || ''
+    return mimeType === 'text/html' || ext === 'html' || ext === 'htm'
+}
 
 interface DocumentViewerProps {
     documentId: string
@@ -26,14 +115,18 @@ export function DocumentViewer({ documentId, onClose }: DocumentViewerProps) {
         const loadDocumentData = async () => {
             setIsLoading(true)
             setError(null)
+            console.log("[DocumentViewer] Loading document:", documentId)
+
             try {
                 // Fetch document metadata
                 const doc = await documentService.getDocument(documentId)
+                console.log("[DocumentViewer] Document loaded:", doc.original_filename, doc.status)
                 setDocument(doc)
 
                 // Fetch extracted text chunks
                 // Limit to 100 chunks for display to avoid forcing too much data
                 const chunksResponse = await documentService.getDocumentChunks(documentId, 100)
+                console.log("[DocumentViewer] Chunks loaded:", chunksResponse.chunks.length)
                 setChunks(chunksResponse.chunks)
 
                 // If it's a text file, fetch the raw content for the preview tab
@@ -45,11 +138,11 @@ export function DocumentViewer({ documentId, onClose }: DocumentViewerProps) {
                             setRawContent(text)
                         }
                     } catch (err) {
-                        console.error("Failed to fetch raw text content:", err)
+                        console.error("[DocumentViewer] Failed to fetch raw text content:", err)
                     }
                 }
             } catch (err) {
-                console.error("Failed to load document data:", err)
+                console.error("[DocumentViewer] Failed to load document:", documentId, err)
                 setError(err instanceof Error ? err.message : "Failed to load document")
             } finally {
                 setIsLoading(false)
@@ -80,13 +173,30 @@ export function DocumentViewer({ documentId, onClose }: DocumentViewerProps) {
             <div className="flex flex-col items-center justify-center h-full p-6 text-center">
                 <AlertCircle className="h-10 w-10 text-destructive mb-4" />
                 <h3 className="text-lg font-semibold text-destructive mb-2">Error Loading Document</h3>
-                <p className="text-muted-foreground">{error}</p>
-                <p className="text-xs text-muted-foreground/50 mt-4">Document ID: {documentId}</p>
+                <p className="text-muted-foreground mb-2">{error}</p>
+                {error === 'Document not found' && (
+                    <p className="text-sm text-muted-foreground max-w-sm">
+                        This document may have been deleted or the database was reset.
+                        Try uploading the document again.
+                    </p>
+                )}
+                <p className="text-xs text-muted-foreground/50 mt-4 font-mono">Document ID: {documentId}</p>
+                {onClose && (
+                    <Button variant="outline" size="sm" className="mt-4" onClick={onClose}>
+                        Close
+                    </Button>
+                )}
             </div>
         )
     }
 
     if (!document) return null
+
+    // Get file type icon and color
+    const { Icon: FileIcon, color: iconColor } = getFileIcon(document.original_filename)
+
+    // Check if this is an HTML document (to hide Preview tab)
+    const isHtml = isHtmlDocument(document.mime_type, document.original_filename)
 
     return (
         <div className="h-full flex flex-col bg-background">
@@ -94,13 +204,7 @@ export function DocumentViewer({ documentId, onClose }: DocumentViewerProps) {
             <div className="flex-shrink-0 p-3 border-b border-border flex items-center justify-between bg-card/50">
                 <div className="flex items-center gap-3 overflow-hidden">
                     <div className="h-10 w-10 rounded-lg bg-primary/10 flex items-center justify-center flex-shrink-0">
-                        {document.mime_type.startsWith('image/') ? (
-                            <ImageIcon className="h-5 w-5 text-primary" />
-                        ) : document.mime_type.startsWith('audio/') ? (
-                            <Music className="h-5 w-5 text-primary" />
-                        ) : (
-                            <Paperclip className="h-5 w-5 text-primary" />
-                        )}
+                        <FileIcon className={`h-5 w-5 ${iconColor}`} />
                     </div>
                     <div className="min-w-0">
                         <h3 className="font-semibold text-sm truncate" title={document.original_filename}>
@@ -127,7 +231,7 @@ export function DocumentViewer({ documentId, onClose }: DocumentViewerProps) {
                 </div>
             </div>
 
-            {/* Tabs */}
+            {/* Tabs - Hide Preview tab for HTML documents as they render poorly in iframe */}
             <Tabs defaultValue="content" className="flex-1 flex flex-col overflow-hidden">
                 <div className="px-3 pt-2 border-b border-border/50 bg-muted/20">
                     <TabsList className="w-full justify-start h-9 bg-transparent p-0 gap-2">
@@ -135,16 +239,18 @@ export function DocumentViewer({ documentId, onClose }: DocumentViewerProps) {
                             value="content"
                             className="data-[state=active]:bg-background data-[state=active]:shadow-sm border border-transparent data-[state=active]:border-border/50 text-xs px-4 h-7 rounded-sm"
                         >
-                            <Paperclip className="h-3 w-3 mr-2" />
+                            <FileText className="h-3 w-3 mr-2" />
                             Content
                         </TabsTrigger>
-                        <TabsTrigger
-                            value="preview"
-                            className="data-[state=active]:bg-background data-[state=active]:shadow-sm border border-transparent data-[state=active]:border-border/50 text-xs px-4 h-7 rounded-sm"
-                        >
-                            <Eye className="h-3 w-3 mr-2" />
-                            Preview
-                        </TabsTrigger>
+                        {!isHtml && (
+                            <TabsTrigger
+                                value="preview"
+                                className="data-[state=active]:bg-background data-[state=active]:shadow-sm border border-transparent data-[state=active]:border-border/50 text-xs px-4 h-7 rounded-sm"
+                            >
+                                <Eye className="h-3 w-3 mr-2" />
+                                Preview
+                            </TabsTrigger>
+                        )}
                     </TabsList>
                 </div>
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,15 +30,15 @@ export default defineConfig(async () => ({
     host: tauriHost || "0.0.0.0",
     hmr: tauriHost
       ? {
-          protocol: "ws",
-          host: tauriHost,
-          port: 1421,
-        }
+        protocol: "ws",
+        host: tauriHost,
+        port: 1421,
+      }
       : {
-          protocol: "ws",
-          host: "0.0.0.0",
-          port: 1421,
-        },
+        protocol: "ws",
+        host: "0.0.0.0",
+        port: 1421,
+      },
     watch: {
       // 3. tell Vite to ignore watching `src-tauri` and `backend` (venv has too many files)
       ignored: ["**/src-tauri/**", "**/backend/**", "**/node_modules/**"],


### PR DESCRIPTION
- Fix document not clearing from input after sending message
- Prevent accidental deletion of documents already sent in messages
- Add file type-specific icons (PDF=red, Word=blue, Excel=green, etc.)
- Hide Preview tab for HTML documents (render poorly in iframe)
- Remove duplicate close buttons in document viewer panel
- Add promise lock to prevent race conditions in chat creation