### PR TITLE
feat: Add async streaming and per-request model selection

### DIFF
--- a/backend/services/llm_providers/openai_compatible.py
+++ b/backend/services/llm_providers/openai_compatible.py
@@ -8,13 +8,14 @@ This provider works with any OpenAI-compatible API endpoint including:
 - Any other OpenAI-compatible endpoint
 """
 
+import asyncio
 import json
 import logging
 import re
 import time
-from typing import Any, Generator, Optional
+from typing import Any, AsyncGenerator, Generator, Optional
 
-from openai import OpenAI  # type: ignore
+from openai import AsyncOpenAI, OpenAI  # type: ignore
 
 from .base import (
     BaseLLMProvider,
@@ -60,17 +61,23 @@ class OpenAICompatibleProvider(BaseLLMProvider):
         """
         super().__init__(base_url, api_key, model)
         self.client: Optional[OpenAI] = None
+        self.async_client: Optional[AsyncOpenAI] = None
         self._init_client()
 
     def _init_client(self) -> None:
-        """Initialize the OpenAI client."""
+        """Initialize the OpenAI clients (sync and async)."""
         if self.base_url:
             self.client = OpenAI(
                 base_url=self.base_url,
                 api_key=self.api_key or "not-required",
             )
+            self.async_client = AsyncOpenAI(
+                base_url=self.base_url,
+                api_key=self.api_key or "not-required",
+            )
         else:
             self.client = None
+            self.async_client = None
 
     def _ensure_client(self) -> bool:
         """Ensure the client is initialized.
@@ -183,7 +190,8 @@ class OpenAICompatibleProvider(BaseLLMProvider):
             request_kwargs["tools"] = tools
             request_kwargs["tool_choice"] = "auto"
 
-        logger.info(f"OpenAI-compatible request: model={self.model}, think={think}, tools={len(tools) if tools else 0}")
+        logger.info(f"OpenAI-compatible request: model={self.model}, think={think}, tools={len(tools) if tools else 0}, base_url={self.base_url}")
+        logger.debug(f"OpenAI-compatible request kwargs: {list(request_kwargs.keys())}")
 
         # Track timing for tokens/second calculation
         start_time = time.time()
@@ -193,10 +201,37 @@ class OpenAICompatibleProvider(BaseLLMProvider):
         try:
             stream = self.client.chat.completions.create(**request_kwargs)
         except Exception as e:
-            # Some providers don't support stream_options, retry without it
-            if "stream_options" in str(e).lower() or "unknown" in str(e).lower():
-                logger.warning("Provider doesn't support stream_options, retrying without usage tracking")
-                del request_kwargs["stream_options"]
+            error_str = str(e).lower()
+            # Handle various provider-specific limitations
+
+            # Check for tool choice issues (vLLM requires special server flags for tools)
+            if ("tool choice" in error_str or
+                "enable-auto-tool-choice" in error_str or
+                "tool-call-parser" in error_str):
+                logger.warning(f"Provider doesn't support tool calling, retrying without tools. Error: {e}")
+                if "tools" in request_kwargs:
+                    del request_kwargs["tools"]
+                if "tool_choice" in request_kwargs:
+                    del request_kwargs["tool_choice"]
+                stream = self.client.chat.completions.create(**request_kwargs)
+            # Check for stream_options issues
+            elif ("stream_options" in error_str or
+                  "unknown" in error_str or
+                  "extra inputs" in error_str or
+                  "validation error" in error_str):
+                logger.warning(f"Provider may not support stream_options, retrying without it. Error: {e}")
+                if "stream_options" in request_kwargs:
+                    del request_kwargs["stream_options"]
+                stream = self.client.chat.completions.create(**request_kwargs)
+            # Generic 400 error - try removing both tools and stream_options
+            elif "400" in error_str:
+                logger.warning(f"Got 400 error, retrying without tools and stream_options. Error: {e}")
+                if "tools" in request_kwargs:
+                    del request_kwargs["tools"]
+                if "tool_choice" in request_kwargs:
+                    del request_kwargs["tool_choice"]
+                if "stream_options" in request_kwargs:
+                    del request_kwargs["stream_options"]
                 stream = self.client.chat.completions.create(**request_kwargs)
             else:
                 raise
@@ -367,6 +402,224 @@ class OpenAICompatibleProvider(BaseLLMProvider):
             logger.info(f"OpenAI-compatible metrics: {completion_tokens} tokens, {tokens_per_second:.2f} tok/s")
 
         # Signal completion with metrics
+        yield StreamChunk(type="done", metrics=metrics)
+
+    async def chat_stream_async(
+        self,
+        messages: list[ChatMessage],
+        temperature: float = 0.7,
+        max_tokens: Optional[int] = None,
+        tools: Optional[list[dict[str, Any]]] = None,
+        think: bool = True,
+    ) -> AsyncGenerator[StreamChunk, None]:
+        """Async version of chat_stream for concurrent request handling.
+
+        Args:
+            messages: List of chat messages
+            temperature: Sampling temperature
+            max_tokens: Maximum tokens to generate
+            tools: Optional list of tool definitions
+            think: Whether to enable thinking detection (default True)
+        """
+        if not self._ensure_client() or not self.async_client:
+            raise RuntimeError("LLM not configured. Please configure LLM settings first.")
+
+        formatted_messages = []
+        for msg in messages:
+            formatted_msg: dict[str, Any] = {"role": msg.role, "content": msg.content}
+            if msg.tool_calls:
+                formatted_msg["tool_calls"] = msg.tool_calls
+            if msg.tool_call_id:
+                formatted_msg["tool_call_id"] = msg.tool_call_id
+            formatted_messages.append(formatted_msg)
+
+        # Build request kwargs
+        request_kwargs: dict[str, Any] = {
+            "model": self.model,
+            "messages": formatted_messages,
+            "temperature": temperature,
+            "stream": True,
+            "stream_options": {"include_usage": True},
+        }
+        if max_tokens:
+            request_kwargs["max_tokens"] = max_tokens
+        if tools:
+            request_kwargs["tools"] = tools
+            request_kwargs["tool_choice"] = "auto"
+
+        logger.info(f"OpenAI-compatible async request: model={self.model}, think={think}, tools={len(tools) if tools else 0}, base_url={self.base_url}")
+
+        # Track timing for tokens/second calculation
+        start_time = time.time()
+        completion_tokens = 0
+        prompt_tokens = 0
+
+        try:
+            stream = await self.async_client.chat.completions.create(**request_kwargs)
+        except Exception as e:
+            error_str = str(e).lower()
+            # Handle various provider-specific limitations
+            if ("tool choice" in error_str or
+                "enable-auto-tool-choice" in error_str or
+                "tool-call-parser" in error_str):
+                logger.warning(f"Provider doesn't support tool calling, retrying without tools. Error: {e}")
+                if "tools" in request_kwargs:
+                    del request_kwargs["tools"]
+                if "tool_choice" in request_kwargs:
+                    del request_kwargs["tool_choice"]
+                stream = await self.async_client.chat.completions.create(**request_kwargs)
+            elif ("stream_options" in error_str or
+                  "unknown" in error_str or
+                  "extra inputs" in error_str or
+                  "validation error" in error_str):
+                logger.warning(f"Provider may not support stream_options, retrying without it. Error: {e}")
+                if "stream_options" in request_kwargs:
+                    del request_kwargs["stream_options"]
+                stream = await self.async_client.chat.completions.create(**request_kwargs)
+            elif "400" in error_str:
+                logger.warning(f"Got 400 error, retrying without tools and stream_options. Error: {e}")
+                if "tools" in request_kwargs:
+                    del request_kwargs["tools"]
+                if "tool_choice" in request_kwargs:
+                    del request_kwargs["tool_choice"]
+                if "stream_options" in request_kwargs:
+                    del request_kwargs["stream_options"]
+                stream = await self.async_client.chat.completions.create(**request_kwargs)
+            else:
+                raise
+
+        # Track tool calls being accumulated during streaming
+        current_tool_calls: dict[int, dict[str, Any]] = {}
+
+        # Track thinking state for tag-based detection
+        in_thinking_block = False
+        content_buffer = ""
+
+        async for chunk in stream:
+            # Handle usage stats
+            if hasattr(chunk, 'usage') and chunk.usage:
+                prompt_tokens = chunk.usage.prompt_tokens or 0
+                completion_tokens = chunk.usage.completion_tokens or 0
+                continue
+
+            if not chunk.choices:
+                continue
+
+            delta = chunk.choices[0].delta
+
+            # Handle content with thinking detection
+            if delta.content:
+                content = clean_llm_output(delta.content)
+                if not content:
+                    continue
+
+                if think:
+                    content_buffer += content
+                    elapsed = time.time() - start_time
+                    completion_tokens += int(len(content) / 4)
+                    tps = completion_tokens / elapsed if elapsed > 0 else 0
+                    partial_metrics = GenerationMetrics(
+                        completion_tokens=completion_tokens,
+                        tokens_per_second=round(tps, 2),
+                        total_duration=round(elapsed, 2)
+                    )
+
+                    if not in_thinking_block:
+                        found_start, _, _ = self._detect_thinking_start(content_buffer)
+                        if found_start:
+                            for pattern in THINKING_START_PATTERNS:
+                                match = re.search(pattern, content_buffer, re.IGNORECASE)
+                                if match:
+                                    before_content = content_buffer[:match.start()]
+                                    if before_content:
+                                        yield StreamChunk(type="content", content=before_content, metrics=partial_metrics)
+                                    content_buffer = content_buffer[match.end():]
+                                    in_thinking_block = True
+                                    break
+                        else:
+                            yield StreamChunk(type="content", content=content_buffer, metrics=partial_metrics)
+                            content_buffer = ""
+
+                    if in_thinking_block:
+                        found_end, _, _ = self._detect_thinking_end(content_buffer)
+                        if found_end:
+                            for pattern in THINKING_END_PATTERNS:
+                                match = re.search(pattern, content_buffer, re.IGNORECASE)
+                                if match:
+                                    thinking_content = content_buffer[:match.start()]
+                                    if thinking_content:
+                                        yield StreamChunk(type="thinking", thinking=thinking_content, metrics=partial_metrics)
+                                    content_buffer = content_buffer[match.end():]
+                                    in_thinking_block = False
+                                    break
+                        elif len(content_buffer) > 100:
+                            yield StreamChunk(type="thinking", thinking=content_buffer, metrics=partial_metrics)
+                            content_buffer = ""
+                else:
+                    elapsed = time.time() - start_time
+                    completion_tokens += int(len(content) / 4)
+                    tps = completion_tokens / elapsed if elapsed > 0 else 0
+                    partial_metrics = GenerationMetrics(
+                        completion_tokens=completion_tokens,
+                        tokens_per_second=round(tps, 2),
+                        total_duration=round(elapsed, 2)
+                    )
+                    yield StreamChunk(type="content", content=content, metrics=partial_metrics)
+
+            # Handle tool calls
+            if delta.tool_calls:
+                for tool_call_delta in delta.tool_calls:
+                    idx = tool_call_delta.index
+                    if idx not in current_tool_calls:
+                        current_tool_calls[idx] = {"id": "", "name": "", "arguments": ""}
+                    if tool_call_delta.id:
+                        current_tool_calls[idx]["id"] = tool_call_delta.id
+                    if tool_call_delta.function:
+                        if tool_call_delta.function.name:
+                            current_tool_calls[idx]["name"] = tool_call_delta.function.name
+                        if tool_call_delta.function.arguments:
+                            current_tool_calls[idx]["arguments"] += tool_call_delta.function.arguments
+
+            finish_reason = chunk.choices[0].finish_reason
+            if finish_reason:
+                logger.info(f"OpenAI-compatible async finish_reason: {finish_reason}")
+
+            if finish_reason == "tool_calls":
+                logger.info(f"OpenAI-compatible async requesting {len(current_tool_calls)} tool call(s)")
+                for idx in sorted(current_tool_calls.keys()):
+                    tc = current_tool_calls[idx]
+                    try:
+                        args = json.loads(tc["arguments"]) if tc["arguments"] else {}
+                    except json.JSONDecodeError:
+                        logger.warning(f"Failed to parse tool arguments: {tc['arguments']}")
+                        args = {}
+                    logger.info(f"  Tool call: {tc['name']} with args: {args}")
+                    yield StreamChunk(
+                        type="tool_call",
+                        tool_call=ToolCall(id=tc["id"], name=tc["name"], arguments=args),
+                    )
+                current_tool_calls = {}
+
+        # Flush remaining buffer
+        if content_buffer:
+            if in_thinking_block:
+                yield StreamChunk(type="thinking", thinking=content_buffer)
+            else:
+                yield StreamChunk(type="content", content=content_buffer)
+
+        # Calculate final metrics
+        end_time = time.time()
+        total_duration = end_time - start_time
+        tokens_per_second = completion_tokens / total_duration if completion_tokens > 0 and total_duration > 0 else None
+        metrics = GenerationMetrics(
+            prompt_tokens=prompt_tokens if prompt_tokens else None,
+            completion_tokens=completion_tokens if completion_tokens else None,
+            total_tokens=(prompt_tokens + completion_tokens) if (prompt_tokens or completion_tokens) else None,
+            total_duration=round(total_duration, 3) if total_duration else None,
+            tokens_per_second=round(tokens_per_second, 2) if tokens_per_second else None,
+        )
+        if tokens_per_second:
+            logger.info(f"OpenAI-compatible async metrics: {completion_tokens} tokens, {tokens_per_second:.2f} tok/s")
         yield StreamChunk(type="done", metrics=metrics)
 
     def is_available(self) -> bool:


### PR DESCRIPTION
- Add chat_stream_async() for non-blocking concurrent LLM requests
- Support request-level provider/model selection (priority over chat settings)
- Improve error handling for provider-specific limitations (vLLM tools, stream_options)
- Fix retry logic to avoid duplicate messages on server errors
- Remove unused OLLAMA_BASE_URL import from frontend